### PR TITLE
[linux-packaging-snippets] control.in: Restrict android-platform-preb…

### DIFF
--- a/control.in
+++ b/control.in
@@ -7,7 +7,7 @@ XS-Droidian-Build-On: @DEB_BUILD_ON@
 Build-Depends: build-essential,
                dpkg-dev,
                findutils,
-               android-platform-prebuilts-python-linux-x86-2.7.5,
+               android-platform-prebuilts-python-linux-x86-2.7.5 [amd64],
                debhelper (>= 13),
                bc,
                rsync,


### PR DESCRIPTION
…uilts-python-linux-x86-2.7.5 to amd64 only

This dependency is not for arm64 native builds.