### PR TITLE
[linux-packaging-snippets] arch: introduce host arch autodetection

### DIFF
--- a/kernel-info.mk.example
+++ b/kernel-info.mk.example
@@ -234,6 +234,8 @@ BUILD_PATH = /usr/lib/llvm-android-$(CLANG_VERSION)/bin
 DEB_TOOLCHAIN = linux-initramfs-halium-generic:arm64, binutils-aarch64-linux-gnu, gcc-4.9-aarch64-linux-android, g++-4.9-aarch64-linux-android, libgcc-4.9-dev-aarch64-linux-android-cross
 
 # Where we're building on
+# Comment DEB_BUILD_ON to enable host arch autodetection.
+# Only amd64 and arm64 archs are supported yet.
 DEB_BUILD_ON = amd64
 
 # Where we're going to run this kernel on

--- a/kernel-snippet.mk
+++ b/kernel-snippet.mk
@@ -27,6 +27,17 @@
 
 include $(CURDIR)/debian/kernel-info.mk
 
+# Host arch detection
+# Comment DEB_BUILD_ON in kernel-info.mk to enable the feature.
+ifndef DEB_BUILD_ON
+HOST_ARCH = $(shell uname -m)
+ifeq ($(HOST_ARCH), aarch64)
+	DEB_BUILD_ON = arm64
+else ifeq ($(HOST_ARCH), x86_64)
+	DEB_BUILD_ON = amd64
+endif
+endif
+
 ifneq (,$(filter parallel=%,$(DEB_BUILD_OPTIONS)))
 	NUMJOBS := $(patsubst parallel=%,%,$(filter parallel=%,$(DEB_BUILD_OPTIONS)))
 else


### PR DESCRIPTION
This change adds the host arch auto detection capabily to the kernel-snippet.mk.

After this implementation, the host architecture where the kernel is going to be compiled, is auto detected.

This avoids the requirement to configure the variable 'DEB_BUILD_ON' in the kernel-info.mk, which is specilly useful for scenarios where the host arch changes frequently.

To enable this feature just remove (or comment) the 'DEB_BUILD_ON' variable from the kernel-info.mk.

Anyway, for backward reasons, the logic located in the kernel-snippet.mk has no preference if the variable is still defined in the kernel-info.mk.

Also the feature is documented in the kernel-info.mk.example.